### PR TITLE
cwc-7: added pagination, sorting in get products endpoint

### DIFF
--- a/src/core/pagination/pagination-response-metadata.interface.ts
+++ b/src/core/pagination/pagination-response-metadata.interface.ts
@@ -1,0 +1,7 @@
+export interface IPaginationResponseMeta {
+  totalItems: number;
+  page: number;
+  pageSize: number;
+  sortBy: string;
+  sortOrder: 'asc' | 'desc';
+}

--- a/src/core/pagination/paginationAndSort.service.ts
+++ b/src/core/pagination/paginationAndSort.service.ts
@@ -1,0 +1,31 @@
+import { Repository, FindManyOptions, FindOptionsOrder } from 'typeorm';
+import { PaginationAndSortingDTO } from './paginationAndSorting.dto';
+import { IPaginationResponseMeta } from './pagination-response-metadata.interface';
+
+export async function paginateAndSort<Entity>(
+  repository: Repository<Entity>,
+  dto: PaginationAndSortingDTO,
+): Promise<{ records: Entity[]; metadata: IPaginationResponseMeta }> {
+  const { page, pageSize, sortBy, sortOrder } = dto;
+
+  const skip = (page - 1) * pageSize;
+  const take = pageSize;
+
+  const findOptions: FindManyOptions<Entity> = {
+    skip,
+    take,
+    order: { [sortBy]: sortOrder } as FindOptionsOrder<Entity>,
+  };
+
+  const [records, totalItems] = await repository.findAndCount(findOptions);
+
+  const paginationMeta: IPaginationResponseMeta = {
+    totalItems,
+    page,
+    pageSize,
+    sortBy,
+    sortOrder,
+  };
+
+  return { records, metadata: paginationMeta };
+}

--- a/src/core/pagination/paginationAndSorting.dto.ts
+++ b/src/core/pagination/paginationAndSorting.dto.ts
@@ -1,0 +1,23 @@
+import { Transform } from 'class-transformer';
+import { IsInt, IsIn, IsOptional } from 'class-validator';
+import { TransformStringToInt } from '../../utils/decorators/stringToInt.decorator';
+
+export class PaginationAndSortingDTO {
+  @Transform((value) => TransformStringToInt(value))
+  @IsInt()
+  @IsOptional()
+  page = 1; // Default value for 'page' is 1
+
+  @Transform((value) => TransformStringToInt(value))
+  @IsInt()
+  @IsOptional()
+  pageSize = 10; // Default value for 'pageSize' is 10
+
+  @IsOptional()
+  @IsIn(['name', 'cost', 'price', 'weight', 'createdAt'])
+  sortBy = 'createdAt'; // Default sorting column
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder: 'asc' | 'desc' = 'desc'; // Default sorting order
+}

--- a/src/modules/product/product.controller.ts
+++ b/src/modules/product/product.controller.ts
@@ -1,22 +1,17 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { Product } from 'src/entities/product.entity';
 import { CreateProductDto } from './dtos/create-product.dto';
 import { ProductService } from './services/product.service';
+import { PaginationAndSortingDTO } from '../../core/pagination/paginationAndSorting.dto';
 
 @Controller('products')
 export class ProductController {
   constructor(private readonly productService: ProductService) {}
 
   @Get()
-  async getAllProducts() {
+  async getAllProducts(@Query() query: PaginationAndSortingDTO) {
     try {
-      const products = await this.productService.getAllProducts();
-      return {
-        records: products,
-        metadata: {
-          count: products.length,
-        },
-      };
+      return await this.productService.getAllProducts(query);
     } catch (error) {
       console.log(error);
     }

--- a/src/modules/product/services/product.service.ts
+++ b/src/modules/product/services/product.service.ts
@@ -3,6 +3,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Product } from 'src/entities/product.entity';
 import { In, Repository } from 'typeorm';
 import { IProduct } from '../interfaces/product';
+import { PaginationAndSortingDTO } from '../../../core/pagination/paginationAndSorting.dto';
+import { paginateAndSort } from '../../../core/pagination/paginationAndSort.service';
+import { IPaginationResponseMeta } from 'src/core/pagination/pagination-response-metadata.interface';
 
 export class ProductService {
   constructor(
@@ -10,9 +13,10 @@ export class ProductService {
     private productRepository: Repository<Product>,
   ) {}
 
-  async getAllProducts(): Promise<Array<Product>> {
-    const products = this.productRepository.find({ order: { createdAt: -1 } });
-    return products;
+  async getAllProducts(
+    paginationAndSortingDto: PaginationAndSortingDTO,
+  ): Promise<{ records: Array<Product>; metadata: IPaginationResponseMeta }> {
+    return paginateAndSort(this.productRepository, paginationAndSortingDto);
   }
 
   async getAllProductsByIds(

--- a/src/utils/decorators/stringToInt.decorator.ts
+++ b/src/utils/decorators/stringToInt.decorator.ts
@@ -1,0 +1,13 @@
+import { TransformFnParams } from 'class-transformer';
+
+export function TransformStringToInt(params: TransformFnParams) {
+  if (params.value === undefined || params.value === null) {
+    return params.value;
+  }
+
+  if (typeof params.value === 'string') {
+    return parseInt(params.value, 10);
+  }
+
+  return params.value;
+}


### PR DESCRIPTION
**Background:**
Added the following actions in get products endpoint:

- pagination
- sorting

**Example:**

- http://localhost:3000/api/v1/products?sortBy=cost&sortOrder=desc
- http://localhost:3000/api/v1/products?page=1
- http://localhost:3000/api/v1/products?pageSize=15&page=2

**Sample Response:**

`{
    "payload": {
        "records": [
            {
                "id": 41,
                "name": "asdadas",
                "description": "asdas",
                "cost": 45000,
                "price": null,
                "weight": "",
                "createdAt": "2023-07-15T13:02:21.809Z"
            },
            {
                "id": 42,
                "name": "Ahsan Product",
                "description": "Ahsan Product Desc",
                "cost": 3000,
                "price": null,
                "weight": "1.4gm",
                "createdAt": "2023-10-21T12:32:08.792Z"
            },
            {
                "id": 33,
                "name": "test8 product",
                "description": "Customize blue color vaaulid with picture printing",
                "cost": 1200,
                "price": 1200,
                "weight": "2.3g",
                "createdAt": "2023-02-25T11:37:22.952Z"
            },
            {
                "id": 38,
                "name": "test10 product",
                "description": "Customize blue color vaaulid with picture printing",
                "cost": 950,
                "price": 1200,
                "weight": "2.3g",
                "createdAt": "2023-02-25T13:26:37.193Z"
            },
            {
                "id": 31,
                "name": "test7 product",
                "description": "Customize blue color vaaulid with picture printing",
                "cost": 700,
                "price": 1200,
                "weight": "2.3g",
                "createdAt": "2023-02-25T11:34:09.889Z"
            },
            {
                "id": 32,
                "name": "test71 product",
                "description": "Customize blue color vaaulid with picture printing",
                "cost": 700,
                "price": 1200,
                "weight": "2.3g",
                "createdAt": "2023-02-25T11:36:04.524Z"
            },
            {
                "id": 35,
                "name": "test9 product",
                "description": "Customize blue color vaaulid with picture printing",
                "cost": 700,
                "price": 1200,
                "weight": "2.3g",
                "createdAt": "2023-02-25T11:38:07.510Z"
            },
            {
                "id": 37,
                "name": "test91 product",
                "description": "Customize blue color vaaulid with picture printing",
                "cost": 700,
                "price": 1200,
                "weight": "2.3g",
                "createdAt": "2023-02-25T11:39:17.912Z"
            },
            {
                "id": 1,
                "name": "Customize vaulid",
                "description": "Customize blue color vaaulid with picture printing",
                "cost": 700,
                "price": 1200,
                "weight": "2.3g",
                "createdAt": "2023-02-10T16:43:28.529Z"
            },
            {
                "id": 4,
                "name": "Customize vaulid 2",
                "description": "Customize blue color vaaulid with picture printing",
                "cost": 700,
                "price": 1200,
                "weight": "2.3g",
                "createdAt": "2023-02-14T06:45:09.229Z"
            }
        ],
        "metadata": {
            "totalItems": 16,
            "page": 1,
            "pageSize": 10,
            "sortBy": "cost",
            "sortOrder": "desc"
        }
    },
    "error": false
}`